### PR TITLE
Update casts for latest Zig

### DIFF
--- a/src/cursor.zig
+++ b/src/cursor.zig
@@ -14,7 +14,7 @@ pub const CursorMode = enum(u8) {
 };
 
 pub fn setCursorMode(writer: anytype, mode: CursorMode) !void {
-    const modeNumber = @enumToInt(mode);
+    const modeNumber = @intFromEnum(mode);
     try writer.print(csi ++ "{d} q", .{modeNumber});
 }
 

--- a/src/style.zig
+++ b/src/style.zig
@@ -96,11 +96,11 @@ pub const FontStyle = packed struct {
     };
 
     pub fn toU11(self: Self) u11 {
-        return @bitCast(u11, self);
+        return @bitCast(self);
     }
 
     pub fn fromU11(bits: u11) Self {
-        return @bitCast(Self, bits);
+        return @bitCast(bits);
     }
 
     /// Returns true iff this font style contains no attributes


### PR DESCRIPTION
This updates to account for the following changes to Zig:

The `@enumToInt` built-in was renamed to `@intFromEnum`.
https://github.com/ziglang/zig/commit/a6c8ee5231230947c928bbe1c6a39eb6e1bb9c5b

Cast primitives dropped their first parameter, instead inferring it based on the destination type. https://ziggit.dev/t/major-zig-language-update-just-landed-removal-of-destination-type-from-all-cast-builtins/898