### PR TITLE
Add "docs" build and CI step

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Documentation
+
+on:
+  push:
+    branches: [master]
+
+  # Allow manually starting the workflow.
+  workflow_dispatch:
+
+# If two concurrent runs are started,
+# prefer the latest one.
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    name: Build docs website
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: goto-bus-stop/setup-zig@v1
+      with:
+        version: master
+    - name: Build
+      run: zig build docs
+    - name: Upload
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: "docs/"
+
+  publish:
+    name: Publish website
+    runs-on: ubuntu-latest
+    needs: build  # wait for build to finish
+    permissions:
+      # Request sufficient permissions to publish the website.
+      pages: write
+      id-token: write
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/docs
 zig-cache/
 deps.zig
 gyro.lock

--- a/build.zig
+++ b/build.zig
@@ -18,4 +18,12 @@ pub fn build(b: *Builder) void {
 
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&run_main_tests.step);
+
+    const docs = b.addTest(.{
+        .root_source_file = .{ .path = "src/main.zig" },
+    });
+    docs.emit_docs = .emit;
+
+    const docs_step = b.step("docs", "Generate documentation");
+    docs_step.dependOn(&docs.step);
 }


### PR DESCRIPTION
**Preview**: A preview of the result of this PR is available at
https://abhinav.github.io/ansi-term/

---

Adds a `zig build docs` step to build documentation website,
and a new GitHub Workflow that publishes the website to GitHub Pages.

This workflow is divided into two jobs:

- build: builds the documentation and uploads it
- publish: downloads the documentation and publishes it

These are separate jobs to minimize permissions available
to the build job.

To use this, you have to take the following steps:

1. Go to **Settings** for the repository
2. Select **Pages** on the left under *Code and automation*
3. Under *Build and deployment* set **Source** to **GitHub Actions**

Note that this workflow dispatches on two events:

- after every push to master
- `workflow_dispatch`: this allows manually running the workflow
  from its *Actions* page if something went wrong

The workflow itself is a separate workflow to make it more copy-paste friendly.

Note on stability:
One of the points made by @joachimschmidt557 in #13 was that
the generated docs must explicitly call out that the documentation is
unstable/WIP.

Because this uses the same tooling as [Zig std][1],
the generated pages include the following header at the top:

> This is a beta autodoc build; expect bugs and missing information.

  [1]: https://ziglang.org/documentation/master/std

Resolves #13