### PR TITLE
README: Add documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ Zig library for dealing with ANSI Terminals (escape codes, styles, etc.)
 This was originally code which was extracted from
 [lscolors](https://github.com/ziglibs/lscolors) for use in
 other zig libraries. More features have been added since.
+
+## Documentation
+
+Automatically generated documentation for the project
+can be found at https://ziglibs.github.io/ansi-term/.
+Note that autodoc is currently in beta; the website may be broken or incomplete.


### PR DESCRIPTION
Adds a documentation section pointing users to https://ziglibs.github.io/ansi-term/ for documentation.