### PR TITLE
Update to master docgen API

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Upload
       uses: actions/upload-pages-artifact@v1
       with:
-        path: "docs/"
+        path: "zig-out/docs/"
 
   publish:
     name: Publish website

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/docs
 zig-cache/
+zig-out/
 deps.zig
 gyro.lock

--- a/build.zig
+++ b/build.zig
@@ -19,11 +19,12 @@ pub fn build(b: *Builder) void {
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&run_main_tests.step);
 
-    const docs = b.addTest(.{
-        .root_source_file = .{ .path = "src/main.zig" },
+    const install_docs = b.addInstallDirectory(.{
+        .source_dir = main_tests.getEmittedDocs(),
+        .install_dir = .prefix,
+        .install_subdir = "docs",
     });
-    docs.emit_docs = .emit;
 
     const docs_step = b.step("docs", "Generate documentation");
-    docs_step.dependOn(&docs.step);
+    docs_step.dependOn(&install_docs.step);
 }


### PR DESCRIPTION
This updates the build.zig to use the latest API for building documentation.

Documentation is now emitted to `zig-out/docs`