### PR TITLE
feat: added suppot for Zig package manager

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3,6 +3,16 @@ const Builder = @import("std").build.Builder;
 pub fn build(b: *Builder) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    // This is the library that can be imported by other programs
+    const lib = b.addStaticLibrary(.{
+        .name = "ansi-term",
+        // In this case the main source file is merely a path, however, in more
+        // complicated build scripts, this could be a generated file.
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(lib);
 
     _ = b.addModule("ansi-term", .{
         .source_file = .{ .path = "src/main.zig" },

--- a/build.zig
+++ b/build.zig
@@ -3,16 +3,6 @@ const Builder = @import("std").build.Builder;
 pub fn build(b: *Builder) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    // This is the library that can be imported by other programs
-    const lib = b.addStaticLibrary(.{
-        .name = "ansi-term",
-        // In this case the main source file is merely a path, however, in more
-        // complicated build scripts, this could be a generated file.
-        .root_source_file = .{ .path = "src/main.zig" },
-        .target = target,
-        .optimize = optimize,
-    });
-    b.installArtifact(lib);
 
     _ = b.addModule("ansi-term", .{
         .source_file = .{ .path = "src/main.zig" },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+    .name = "ansi-term",
+    .version = "0.0.0",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "LICENSE",
+        "README.md",
+    },
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,10 +2,6 @@
     .name = "ansi-term",
     .version = "0.0.0",
     .paths = .{
-        "build.zig",
-        "build.zig.zon",
         "src",
-        "LICENSE",
-        "README.md",
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,6 +2,8 @@
     .name = "ansi-term",
     .version = "0.0.0",
     .paths = .{
-        "src",
+        "build.zig",
+        "build.zig.zon",
+        "src/",
     },
 }


### PR DESCRIPTION
This adds the build.zig.zon file and updates to build.zig to make this project usable by projects that use the Zig package manager. I was able to test this in a project I was working on and it worked as expected!