### PR TITLE
chore: port to Zig 0.14.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: mlugg/setup-zig@v1
       with:
-        version: 0.13.0
+        version: 0.14.0
     - name: Build
       run: zig build docs
     - name: Upload

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: mlugg/setup-zig@v1
       with:
-        version: 0.13.0
+        version: 0.14.0
     - name: Build
       run: zig build test

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,8 @@
 .{
-    .name = "ansi-term",
+    .name = .ansi_term,
     .version = "0.0.0",
+    .fingerprint = 0xa403c76fcb80b6fd,
+
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
This updates the library to Zig 0.14.0. A random fingerprint has been generated. The binary as well as docs build and all tests pass.

The CI seems to be broken, but I'm not sure what's causing it to fail.